### PR TITLE
Update kube-rbac-proxy image to use quay.io/brancz/kube-rbac-proxy

### DIFF
--- a/charts/cosmo-controller-manager/Chart.yaml
+++ b/charts/cosmo-controller-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cosmo-controller-manager
 description: COSMO Controller Manager Helm chart for Kubernetes
 type: application
-version: 0.2.0-rc1
+version: 0.2.0-rc2
 appVersion: v0.2.0-rc1
 kubeVersion: ">= 1.19.0-0"
 home: https://github.com/cosmo-workspace/cosmo

--- a/charts/cosmo-controller-manager/values.yaml
+++ b/charts/cosmo-controller-manager/values.yaml
@@ -11,9 +11,9 @@ image:
   tag: ""
 
 imageK8sRbacProxy:
-  repository: gcr.io/kubebuilder/kube-rbac-proxy
+  repository: quay.io/brancz/kube-rbac-proxy
   pullPolicy: IfNotPresent
-  tag: "v0.8.0"
+  tag: "v0.11.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
`gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` has security alert in ArtifactHub. 

Until `gcr.io/kubebuilder/kube-rbac-proxy` updates, use `quay.io/brancz/kube-rbac-proxy:v0.11.0`